### PR TITLE
Allow for configuration of debug mode and listener timeouts

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,0 +1,1 @@
+package cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ func init() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "debug")
-	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
+	_ = viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 }
 
 func createLogger() (logger *zap.Logger) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+	"log"
+	"strings"
 )
 
 var (
@@ -9,13 +14,31 @@ var (
 		Use:   "tuber",
 		Short: "",
 	}
-
-	app string
 )
+
+func init() {
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
+	rootCmd.PersistentFlags().BoolP("debug", "d", false, "debug")
+	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
+}
+
+func createLogger() (logger *zap.Logger) {
+	if viper.GetBool("debug") {
+		logger, _ = zap.NewDevelopment()
+	} else {
+		logger, _ = zap.NewProduction()
+	}
+	return
+}
 
 // Execute executes
 func Execute() error {
-	rootCmd.PersistentFlags().StringVarP(&app, "app", "a", "", "app name")
+	err := godotenv.Load()
+	if err == nil {
+		log.Println(".env file loaded")
+	}
 
 	return rootCmd.Execute()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,11 @@ var (
 )
 
 func init() {
+	// Environment variables prefixed with `TUBER_` are immediately available
+	// to Viper with '-' substitution. E.g., `TUBER_DEBUG=true` is available as
+	// `viper.GetBool("debug")`
 	viper.AutomaticEnv()
+	viper.SetEnvPrefix("TUBER")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "debug")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -66,7 +66,7 @@ func start(cmd *cobra.Command, args []string) {
 	if viper.IsSet("max-accept") {
 		options = append(options, listener.WithMaxAccept(viper.GetInt("max-accept")))
 	}
-	
+
 	if viper.IsSet("max-timeout") {
 		options = append(options, listener.WithMaxTimeout(viper.GetDuration("max-timeout")))
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -14,7 +14,6 @@ import (
 
 func init() {
 	rootCmd.AddCommand(startCmd)
-
 }
 
 var startCmd = &cobra.Command{
@@ -63,10 +62,11 @@ func start(cmd *cobra.Command, args []string) {
 	bindShutdown(logger, cancel)
 
 	// create a new PubSub listener
-	var options = make([]listener.ListenerOption, 0)
+	var options = make([]listener.Option, 0)
 	if viper.IsSet("max-accept") {
 		options = append(options, listener.WithMaxAccept(viper.GetInt("max-accept")))
 	}
+	
 	if viper.IsSet("max-timeout") {
 		options = append(options, listener.WithMaxTimeout(viper.GetDuration("max-timeout")))
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -81,6 +81,7 @@ func start(cmd *cobra.Command, args []string) {
 	// Create error channel
 	var errorChan = createErrorChannel(logger)
 
+	viper.BindEnv("gcloud-token", "GCLOUD_TOKEN")
 	var token = viper.GetString("gcloud-token")
 
 	// Create a new streamer

--- a/pkg/listener/listen.go
+++ b/pkg/listener/listen.go
@@ -12,8 +12,9 @@ import (
 	"google.golang.org/api/option"
 )
 
-type listener struct {
-	projectId    string
+//Listener binds to a pubsub subscription and sends messages to a queue
+type Listener struct {
+	projectID    string
 	subscription string
 
 	in   chan *util.RegistryEvent
@@ -24,27 +25,27 @@ type listener struct {
 	recvSettings pubsub.ReceiveSettings
 }
 
-// ListenerOption provides optional settings to a listener constructor
-type ListenerOption func(*listener)
+// Option provides optional settings to a Listener constructor
+type Option func(*Listener)
 
 // WithMaxAccept determines the maximum number of outstanding messages accepted
-func WithMaxAccept(n int) ListenerOption {
-	return func(l *listener) {
+func WithMaxAccept(n int) Option {
+	return func(l *Listener) {
 		l.recvSettings.MaxOutstandingMessages = n
 	}
 }
 
 // WithMaxTimeout sets the maximum ack timeout extension
-func WithMaxTimeout(d time.Duration) ListenerOption {
-	return func(l *listener) {
+func WithMaxTimeout(d time.Duration) Option {
+	return func(l *Listener) {
 		l.recvSettings.MaxExtension = d
 	}
 }
 
-// NewListener creates a new PubSub listener
-func NewListener(logger *zap.Logger, options ...ListenerOption) *listener {
-	var l = &listener{
-		projectId:    "freshly-docker",
+// NewListener creates a new PubSub Listener
+func NewListener(logger *zap.Logger, options ...Option) *Listener {
+	var l = &Listener{
+		projectID:    "freshly-docker",
 		subscription: "freshly-docker-gcr-events",
 
 		in:           make(chan *util.RegistryEvent, 1),
@@ -61,21 +62,21 @@ func NewListener(logger *zap.Logger, options ...ListenerOption) *listener {
 }
 
 // Listen for incoming pubsub requests
-func (l *listener) Listen(ctx context.Context) (<-chan *util.RegistryEvent, chan<- *util.RegistryEvent, error) {
+func (l *Listener) Listen(ctx context.Context) (<-chan *util.RegistryEvent, chan<- *util.RegistryEvent, error) {
 	go l.startAcker(ctx)
 
 	var err = l.startListener(ctx)
 	return l.in, l.out, err
 }
 
-func (l *listener) startListener(ctx context.Context) error {
+func (l *Listener) startListener(ctx context.Context) error {
 	var client *pubsub.Client
 	var err error
 
-	client, err = pubsub.NewClient(ctx, l.projectId, option.WithCredentialsFile("./credentials.json"))
+	client, err = pubsub.NewClient(ctx, l.projectID, option.WithCredentialsFile("./credentials.json"))
 
 	if err != nil {
-		client, err = pubsub.NewClient(ctx, l.projectId)
+		client, err = pubsub.NewClient(ctx, l.projectID)
 	}
 
 	if err != nil {
@@ -93,8 +94,8 @@ func (l *listener) startListener(ctx context.Context) error {
 		// Close the message channel before exiting to signal to downstream that we're done
 		defer close(in)
 
-		l.logger.Info("listener: starting")
-		l.logger.Debug("listener: subscription options", zap.Reflect("options", subscription.ReceiveSettings))
+		l.logger.Info("Listener: starting")
+		l.logger.Debug("Listener: subscription options", zap.Reflect("options", subscription.ReceiveSettings))
 		err = subscription.Receive(ctx,
 			func(ctx context.Context, message *pubsub.Message) {
 				obj := &util.RegistryEvent{Message: message}
@@ -108,15 +109,15 @@ func (l *listener) startListener(ctx context.Context) error {
 			})
 
 		if err != nil {
-			l.logger.With(zap.Error(err)).Warn("listener: receiver error")
+			l.logger.With(zap.Error(err)).Warn("Listener: receiver error")
 		}
-		l.logger.Info("listener: shutting down")
+		l.logger.Info("Listener: shutting down")
 	}(l.in, l.logger)
 
 	return err
 }
 
-func (l *listener) startAcker(ctx context.Context) {
+func (l *Listener) startAcker(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
 	}
@@ -131,12 +132,13 @@ func (l *listener) startAcker(ctx context.Context) {
 		//event.Message.Ack()
 		l.logger.With(zap.Reflect("event", event)).Debug("did not ack")
 	}
+
 	l.logger.Info("acknowledge loop: stopped")
 }
 
-// Wait for the listener and acker goroutines to exit.
+// Wait for the Listener and acker goroutines to exit.
 // If you use this method, you must ensure that you close
 // the output channel when no more work is being processed
-func (l *listener) Wait() {
+func (l *Listener) Wait() {
 	l.wait.Wait()
 }

--- a/pkg/listener/listen.go
+++ b/pkg/listener/listen.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"go.uber.org/zap"
-	"log"
 	"sync"
+	"time"
 	"tuber/pkg/util"
 
 	"cloud.google.com/go/pubsub"
@@ -13,19 +13,49 @@ import (
 )
 
 type listener struct {
-	logger *zap.Logger
-	in     chan *util.RegistryEvent
-	out    chan *util.RegistryEvent
-	wait   *sync.WaitGroup
+	projectId    string
+	subscription string
+
+	in   chan *util.RegistryEvent
+	out  chan *util.RegistryEvent
+	wait *sync.WaitGroup
+
+	logger       *zap.Logger
+	recvSettings pubsub.ReceiveSettings
+}
+
+// ListenerOption provides optional settings to a listener constructor
+type ListenerOption func(*listener)
+
+// WithMaxAccept determines the maximum number of outstanding messages accepted
+func WithMaxAccept(n int) ListenerOption {
+	return func(l *listener) {
+		l.recvSettings.MaxOutstandingMessages = n
+	}
+}
+
+// WithMaxTimeout sets the maximum ack timeout extension
+func WithMaxTimeout(d time.Duration) ListenerOption {
+	return func(l *listener) {
+		l.recvSettings.MaxExtension = d
+	}
 }
 
 // NewListener creates a new PubSub listener
-func NewListener(logger *zap.Logger) *listener {
+func NewListener(logger *zap.Logger, options ...ListenerOption) *listener {
 	var l = &listener{
-		logger: logger,
-		in:     make(chan *util.RegistryEvent, 1),
-		out:    make(chan *util.RegistryEvent, 1),
-		wait:   &sync.WaitGroup{},
+		projectId:    "freshly-docker",
+		subscription: "freshly-docker-gcr-events",
+
+		in:           make(chan *util.RegistryEvent, 1),
+		out:          make(chan *util.RegistryEvent, 1),
+		wait:         &sync.WaitGroup{},
+		logger:       logger,
+		recvSettings: pubsub.ReceiveSettings{},
+	}
+
+	for _, option := range options {
+		option(l)
 	}
 	return l
 }
@@ -39,32 +69,21 @@ func (l *listener) Listen(ctx context.Context) (<-chan *util.RegistryEvent, chan
 }
 
 func (l *listener) startListener(ctx context.Context) error {
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
-
 	var client *pubsub.Client
 	var err error
 
-	client, err = pubsub.NewClient(ctx, "freshly-docker", option.WithCredentialsFile("./credentials.json"))
+	client, err = pubsub.NewClient(ctx, l.projectId, option.WithCredentialsFile("./credentials.json"))
 
 	if err != nil {
-		client, err = pubsub.NewClient(ctx, "freshly-docker")
+		client, err = pubsub.NewClient(ctx, l.projectId)
 	}
 
 	if err != nil {
 		return err
 	}
 
-	subscription := client.Subscription("freshly-docker-gcr-events")
-	cfg, err := subscription.Config(ctx)
-
-	if err != nil {
-		return err
-	}
-
-	// Set a fixed deadline and small outstanding message count for testing
-	// TODO: Remove or make configurable
-	subscription.ReceiveSettings.MaxExtension = cfg.AckDeadline
-	subscription.ReceiveSettings.MaxOutstandingMessages = 5
+	subscription := client.Subscription(l.subscription)
+	subscription.ReceiveSettings = l.recvSettings
 
 	go func(in chan<- *util.RegistryEvent, logger *zap.Logger) {
 		// Register this goroutine in the waiter
@@ -74,23 +93,24 @@ func (l *listener) startListener(ctx context.Context) error {
 		// Close the message channel before exiting to signal to downstream that we're done
 		defer close(in)
 
-		l.logger.Info("Listener: starting")
+		l.logger.Info("listener: starting")
+		l.logger.Debug("listener: subscription options", zap.Reflect("options", subscription.ReceiveSettings))
 		err = subscription.Receive(ctx,
 			func(ctx context.Context, message *pubsub.Message) {
 				obj := &util.RegistryEvent{Message: message}
 				jsonErr := json.Unmarshal(message.Data, obj)
 
 				if jsonErr != nil {
-					l.logger.Warn("Could not unmarshal message")
+					l.logger.Warn("could not unmarshal message")
 				} else {
 					in <- obj
 				}
 			})
 
 		if err != nil {
-			l.logger.With(zap.Error(err)).Warn("Listener: Receiver error")
+			l.logger.With(zap.Error(err)).Warn("listener: receiver error")
 		}
-		l.logger.Info("Listener: shutting down")
+		l.logger.Info("listener: shutting down")
 	}(l.in, l.logger)
 
 	return err
@@ -105,13 +125,13 @@ func (l *listener) startAcker(ctx context.Context) {
 	l.wait.Add(1)
 	defer l.wait.Done()
 
-	l.logger.Info("Acknowledge loop: starting")
+	l.logger.Info("acknowledge loop: starting")
 
 	for event := range l.out {
 		//event.Message.Ack()
-		l.logger.With(zap.Reflect("event", event)).Info("Did not ack")
+		l.logger.With(zap.Reflect("event", event)).Debug("did not ack")
 	}
-	l.logger.Info("Acknowledge loop: stopped")
+	l.logger.Info("acknowledge loop: stopped")
 }
 
 // Wait for the listener and acker goroutines to exit.


### PR DESCRIPTION
This time there is no slash in the branch name.

This PR adds configuration for debug via a command-line switch and max-timeout / max-outstanding via environment variables (MAX_TIMEOUT and MAX_OUTSTANDING -- or something).

I guess I should have used the prefix thing so it'd be TUBER_MAX_OUTSTANDING but I didn't.
