### PR TITLE
Make Pub/Sub Subscription Name Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 # tuber 
 
 ![logo](logo.png)
+
+## Environment Variables
+* `TUBER_PUBSUB_SUBSCRIPTION_NAME`

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -73,6 +73,8 @@ func start(cmd *cobra.Command, args []string) {
 		options = append(options, listener.WithMaxTimeout(viper.GetDuration("max-timeout")))
 	}
 
+	}
+
 	var l = listener.NewListener(logger, options...)
 
 	creds, err := credentials()

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -73,6 +73,9 @@ func start(cmd *cobra.Command, args []string) {
 		options = append(options, listener.WithMaxTimeout(viper.GetDuration("max-timeout")))
 	}
 
+	viper.SetDefault("subscription-name", "freshly-docker-gcr-events")
+	if viper.IsSet("subscription-name") {
+		options = append(options, listener.WithSubscriptionName(viper.GetString("subscription-name")))
 	}
 
 	var l = listener.NewListener(logger, options...)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -73,7 +73,6 @@ func start(cmd *cobra.Command, args []string) {
 		options = append(options, listener.WithMaxTimeout(viper.GetDuration("max-timeout")))
 	}
 
-	viper.SetDefault("subscription-name", "freshly-docker-gcr-events")
 	if viper.IsSet("subscription-name") {
 		options = append(options, listener.WithSubscriptionName(viper.GetString("subscription-name")))
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -73,8 +73,8 @@ func start(cmd *cobra.Command, args []string) {
 		options = append(options, listener.WithMaxTimeout(viper.GetDuration("max-timeout")))
 	}
 
-	if viper.IsSet("subscription-name") {
-		options = append(options, listener.WithSubscriptionName(viper.GetString("subscription-name")))
+	if viper.IsSet("pubsub-subscription-name") {
+		options = append(options, listener.WithSubscriptionName(viper.GetString("pubsub-subscription-name")))
 	}
 
 	var l = listener.NewListener(logger, options...)

--- a/pkg/listener/listen.go
+++ b/pkg/listener/listen.go
@@ -47,16 +47,12 @@ func WithMaxTimeout(d time.Duration) Option {
 	}
 }
 
-func WithSubscriptionName(n string) Option {
-	return func(l *listener) {
-		l.subscription = n
-	}
-}
-
 // NewListener creates a new PubSub listener
-func NewListener(logger *zap.Logger, options ...Option) *listener {
+func NewListener(logger *zap.Logger, subscriptionName string, options ...Option) *listener {
 	var l = &listener{
-		projectID:        "freshly-docker",
+		projectID:    "freshly-docker",
+		subscription: subscriptionName,
+
 		unprocessed:      make(chan *RegistryEvent, 1),
 		processed:        make(chan *RegistryEvent, 1),
 		failures:         make(chan FailedRelease, 1),

--- a/pkg/listener/listen.go
+++ b/pkg/listener/listen.go
@@ -62,8 +62,8 @@ func NewListener(logger *zap.Logger, subscriptionName string, options ...Option)
 		recvSettings:     pubsub.ReceiveSettings{},
 	}
 
-	for _, option := range options {
-		option(l)
+	for _, op := range options {
+		op(l)
 	}
 	return l
 }

--- a/pkg/listener/listen.go
+++ b/pkg/listener/listen.go
@@ -56,9 +56,7 @@ func WithSubscriptionName(n string) Option {
 // NewListener creates a new PubSub listener
 func NewListener(logger *zap.Logger, options ...Option) *listener {
 	var l = &listener{
-		projectID:    "freshly-docker",
-		subscription: "freshly-docker-gcr-events",
-
+		projectID:        "freshly-docker",
 		unprocessed:      make(chan *RegistryEvent, 1),
 		processed:        make(chan *RegistryEvent, 1),
 		failures:         make(chan FailedRelease, 1),

--- a/pkg/listener/listen.go
+++ b/pkg/listener/listen.go
@@ -47,6 +47,12 @@ func WithMaxTimeout(d time.Duration) Option {
 	}
 }
 
+func WithSubscriptionName(n string) Option {
+	return func(l *listener) {
+		l.subscription = n
+	}
+}
+
 // NewListener creates a new PubSub listener
 func NewListener(logger *zap.Logger, options ...Option) *listener {
 	var l = &listener{


### PR DESCRIPTION
Unsure of a few things here
* Should the default be enforced at the viper/env var level, or inside of the `NewListener` initializer? (I left both for now)
* Should this setting even use the whole `func WithSetting() Option` pattern, or does it deserve it's own argument space in the initializer?

I'm open to creating a "default" subscription inside `freshly-docker` and using that as the default value for this, but I'm partial to enforcing an env var to configure this. The risk is that if I deploy a new tuber to a different cluster, and the default is a subscription that another tuber uses, they will ack each other's messages.