### PR TITLE
Refactor Install Command

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"sort"
 	"tuber/pkg/core"
-	"tuber/pkg/k8s"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -26,16 +25,8 @@ var appsInstallCmd = &cobra.Command{
 		appName := args[0]
 		repo := args[1]
 		tag := args[2]
-		existsAlready, err := k8s.Exists("namespace", appName, appName)
-		if err != nil {
-			return err
-		}
 
-		if existsAlready {
-			return core.AddAppConfig(appName, repo, tag)
-		}
-
-		err = core.NewAppSetup(appName, istioEnabled)
+		err := core.NewAppSetup(appName, istioEnabled)
 		if err != nil {
 			return err
 		}

--- a/pkg/k8s/secrets.go
+++ b/pkg/k8s/secrets.go
@@ -123,14 +123,5 @@ func RemoveSecretEntry(mapName string, namespace string, key string) (err error)
 
 // CreateEnv creates a Secret for a new TuberApp, to store env vars
 func CreateEnv(appName string) error {
-	existsAlready, err := Exists("namespace", appName, appName)
-	if err != nil {
-		return err
-	}
-
-	if existsAlready {
-		return nil
-	}
-
 	return Create(appName, "secret", "generic", appName+"-env")
 }


### PR DESCRIPTION
* Checks for existence of env file, not namespace, before creating the env file
* Never deletes namespace; prefers partial failures with good error messages along the way
* Removes exists already checks from `k8s.CreateEnv` function. It's now up to the caller to decided to do that. Plus, k8s create command errors if resource already exists (I think)