### PR TITLE
Support Multiple Pending Releases

### DIFF
--- a/pkg/events/filter.go
+++ b/pkg/events/filter.go
@@ -5,17 +5,19 @@ import (
 	"tuber/pkg/listener"
 )
 
-func filter(e *listener.RegistryEvent) (event *core.TuberApp, err error) {
+func filter(e *listener.RegistryEvent) ([]core.TuberApp, error) {
 	apps, err := core.TuberApps()
+	var filteredApps []core.TuberApp
 
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	for _, app := range apps {
 		if app.ImageTag == e.Tag {
-			return &app, nil
+			filteredApps = append(filteredApps, app)
 		}
 	}
-	return
+
+	return filteredApps, nil
 }


### PR DESCRIPTION
Currently, Tuber finds pending releases by matching on image tag. This doesn't work for apps like the resque dashboard, which are deployed as three instances of the same app, with the same image tag, and different names. 

For example, `resque-admin-prod`, `resque-admin-staging`. When running `tuber deploy`, tuber would find the first matching image tag and deploy that app. 

This change allows tuber to find all apps with a matching image tag and deploy them.