### PR TITLE
I think this is all I need to do?

### DIFF
--- a/pkg/events/stream.go
+++ b/pkg/events/stream.go
@@ -39,6 +39,7 @@ func (s *streamer) Stream(unprocessed <-chan *listener.RegistryEvent, processed 
 				if err != nil {
 					chErr <- listener.FailedRelease{Err: err, Event: event}
 					chErrReports <- err
+					processed <- event
 				} else {
 					processed <- event
 				}


### PR DESCRIPTION
Right now, when there is a config error or something invalid about applying the tubernetes for an event that event will be re-returned to the pubsub queue because the deadline was extended, but never ack'd. What ends up happening is a simple typo plugs up the pubsub queue for a tuber and everything needs to get purged or the specific event needs to be surgically removed.

Solution: Ack an event if there was an error, assuming any error will always re-fail. This probably isn't true about something like a tuber permission or config var, but that scenario is much easier to resolve with a `tuber deploy` than clearing pubsub messages.