### PR TITLE
POPS-698 Pause and Unpause Releases

### DIFF
--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"tuber/pkg/k8s"
+
+	"github.com/spf13/cobra"
+)
+
+var pauseCmd = &cobra.Command{
+	SilenceUsage: true,
+	Use:          "pause [app name]",
+	Short:        "pause deploys for the specified app",
+	Args:         cobra.ExactArgs(1),
+	PreRunE:      promptCurrentContext,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		appName := args[0]
+
+		exists, err := k8s.Exists("configmap", "tuber-app-pauses", "tuber")
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			err = k8s.Create("tuber", "configmap", "tuber-app-pauses")
+			if err != nil {
+				return err
+			}
+		}
+
+		return k8s.PatchConfigMap("tuber-app-pauses", "tuber", appName, "true")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pauseCmd)
+}

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"tuber/pkg/k8s"
+	"tuber/pkg/core"
 
 	"github.com/spf13/cobra"
 )
@@ -14,20 +14,7 @@ var pauseCmd = &cobra.Command{
 	PreRunE:      promptCurrentContext,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		appName := args[0]
-
-		exists, err := k8s.Exists("configmap", "tuber-app-pauses", "tuber")
-		if err != nil {
-			return err
-		}
-
-		if !exists {
-			err = k8s.Create("tuber", "configmap", "tuber-app-pauses")
-			if err != nil {
-				return err
-			}
-		}
-
-		return k8s.PatchConfigMap("tuber-app-pauses", "tuber", appName, "true")
+		return core.PauseDeployments(appName)
 	},
 }
 

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"tuber/pkg/k8s"
+	"tuber/pkg/core"
 
 	"github.com/spf13/cobra"
 )
@@ -14,17 +14,7 @@ var resumeCmd = &cobra.Command{
 	PreRunE:      promptCurrentContext,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		appName := args[0]
-
-		exists, err := k8s.Exists("configmap", "tuber-app-pauses", "tuber")
-		if err != nil {
-			return err
-		}
-
-		if !exists {
-			return nil
-		}
-
-		return k8s.RemoveConfigMapEntry("tuber-app-pauses", "tuber", appName)
+		return core.ResumeDeployments(appName)
 	},
 }
 

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"tuber/pkg/k8s"
+
+	"github.com/spf13/cobra"
+)
+
+var resumeCmd = &cobra.Command{
+	SilenceUsage: true,
+	Use:          "resume [app name]",
+	Short:        "resume deploys for the specified app",
+	Args:         cobra.ExactArgs(1),
+	PreRunE:      promptCurrentContext,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		appName := args[0]
+
+		exists, err := k8s.Exists("configmap", "tuber-app-pauses", "tuber")
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			return nil
+		}
+
+		return k8s.RemoveConfigMapEntry("tuber-app-pauses", "tuber", appName)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(resumeCmd)
+}

--- a/pkg/core/deployments.go
+++ b/pkg/core/deployments.go
@@ -2,9 +2,11 @@ package core
 
 import "tuber/pkg/k8s"
 
+const tuberAppPauses = "tuber-app-pauses"
+
 // ReleasesPaused checks the tuber-app-pauses configmap for the presence of the given app
 func ReleasesPaused(appName string) (bool, error) {
-	config, err := k8s.GetConfigResource("tuber-app-pauses", "tuber", "ConfigMap")
+	config, err := k8s.GetConfigResource(tuberAppPauses, "tuber", "ConfigMap")
 	if err != nil {
 		return false, err
 	}
@@ -14,23 +16,23 @@ func ReleasesPaused(appName string) (bool, error) {
 
 // PauseDeployments adds an app to the tuber-app-pauses configmap
 func PauseDeployments(appName string) error {
-	exists, err := k8s.Exists("configmap", "tuber-app-pauses", "tuber")
+	exists, err := k8s.Exists("configmap", tuberAppPauses, "tuber")
 	if err != nil {
 		return err
 	}
 
 	if !exists {
-		if err = k8s.Create("tuber", "configmap", "tuber-app-pauses"); err != nil {
+		if err = k8s.Create("tuber", "configmap", tuberAppPauses); err != nil {
 			return err
 		}
 	}
 
-	return k8s.PatchConfigMap("tuber-app-pauses", "tuber", appName, "true")
+	return k8s.PatchConfigMap(tuberAppPauses, "tuber", appName, "true")
 }
 
 // ResumeDeployments removes an app from the tuber-app-pauses configmap
 func ResumeDeployments(appName string) error {
-	exists, err := k8s.Exists("configmap", "tuber-app-pauses", "tuber")
+	exists, err := k8s.Exists("configmap", tuberAppPauses, "tuber")
 	if err != nil {
 		return err
 	}
@@ -39,5 +41,5 @@ func ResumeDeployments(appName string) error {
 		return nil
 	}
 
-	return k8s.RemoveConfigMapEntry("tuber-app-pauses", "tuber", appName)
+	return k8s.RemoveConfigMapEntry(tuberAppPauses, "tuber", appName)
 }

--- a/pkg/core/deployments.go
+++ b/pkg/core/deployments.go
@@ -2,8 +2,8 @@ package core
 
 import "tuber/pkg/k8s"
 
-// IsPaused checks the tuber-app-pauses configmap for the presence of the given app
-func IsPaused(appName string) (bool, error) {
+// ReleasesPaused checks the tuber-app-pauses configmap for the presence of the given app
+func ReleasesPaused(appName string) (bool, error) {
 	config, err := k8s.GetConfigResource("tuber-app-pauses", "tuber", "ConfigMap")
 	if err != nil {
 		return false, err

--- a/pkg/core/deployments.go
+++ b/pkg/core/deployments.go
@@ -1,0 +1,43 @@
+package core
+
+import "tuber/pkg/k8s"
+
+// IsPaused checks the tuber-app-pauses configmap for the presence of the given app
+func IsPaused(appName string) (bool, error) {
+	config, err := k8s.GetConfigResource("tuber-app-pauses", "tuber", "ConfigMap")
+	if err != nil {
+		return false, err
+	}
+
+	return config.Data[appName] == "true", nil
+}
+
+// PauseDeployments adds an app to the tuber-app-pauses configmap
+func PauseDeployments(appName string) error {
+	exists, err := k8s.Exists("configmap", "tuber-app-pauses", "tuber")
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		if err = k8s.Create("tuber", "configmap", "tuber-app-pauses"); err != nil {
+			return err
+		}
+	}
+
+	return k8s.PatchConfigMap("tuber-app-pauses", "tuber", appName, "true")
+}
+
+// ResumeDeployments removes an app from the tuber-app-pauses configmap
+func ResumeDeployments(appName string) error {
+	exists, err := k8s.Exists("configmap", "tuber-app-pauses", "tuber")
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return nil
+	}
+
+	return k8s.RemoveConfigMapEntry("tuber-app-pauses", "tuber", appName)
+}

--- a/pkg/events/processor.go
+++ b/pkg/events/processor.go
@@ -56,17 +56,18 @@ func (p Processor) ProcessMessage(digest string, tag string) {
 	matchFound := false
 	for _, app := range apps {
 		if app.ImageTag == event.tag {
-			paused, err := core.IsPaused(app.Name)
+			matchFound = true
+
+			paused, err := core.ReleasesPaused(app.Name)
 			if err != nil {
 				event.logger.Error("failed to check for paused state", zap.Error(err))
 			}
 
 			if paused {
-				event.logger.Warn("app deployments paused; skipping")
+				event.logger.Warn("app deployments paused; skipping", zap.Bool("paused", true))
 				continue
 			}
 
-			matchFound = true
 			p.startRelease(event, &app)
 		}
 	}

--- a/pkg/events/processor.go
+++ b/pkg/events/processor.go
@@ -56,6 +56,16 @@ func (p Processor) ProcessMessage(digest string, tag string) {
 	matchFound := false
 	for _, app := range apps {
 		if app.ImageTag == event.tag {
+			paused, err := core.IsPaused(app.Name)
+			if err != nil {
+				event.logger.Error("failed to check for paused state", zap.Error(err))
+			}
+
+			if paused {
+				event.logger.Warn("app deployments paused; skipping")
+				continue
+			}
+
 			matchFound = true
 			p.startRelease(event, &app)
 		}
@@ -91,7 +101,6 @@ func (p Processor) startRelease(event event, app *core.TuberApp) {
 	logger.Info("release starting")
 
 	prereleaseYamls, releaseYamls, err := containers.GetTuberLayer(app.GetRepositoryLocation(), p.creds)
-
 	if err != nil {
 		logger.Error("failed to find tuber layer", zap.Error(err))
 		report.Error(err, errorScope.WithContext("find tuber layer"))
@@ -102,7 +111,6 @@ func (p Processor) startRelease(event event, app *core.TuberApp) {
 		logger.Info("prerelease starting")
 
 		err = core.RunPrerelease(prereleaseYamls, app, event.digest, p.clusterData)
-
 		if err != nil {
 			report.Error(err, errorScope.WithContext("prerelease"))
 			logger.Error("failed prerelease", zap.Error(err))

--- a/pkg/events/processor.go
+++ b/pkg/events/processor.go
@@ -64,7 +64,7 @@ func (p Processor) ProcessMessage(digest string, tag string) {
 			}
 
 			if paused {
-				event.logger.Warn("app deployments paused; skipping", zap.Bool("paused", true))
+				event.logger.Warn("app deployments paused; skipping", zap.String("appName", app.Name))
 				continue
 			}
 


### PR DESCRIPTION
## What does this PR Do
* Adds `pause [app]` and `resume [app]` commands 
* Discards deployments if an app is paused

The app pauses are stored in a configmap that looks like this:
```yaml
# tuber-app-pauses
data:
  account-service: true
```

Pausing and unpausing apps adds/removes apps from the configmap. 