### PR TITLE
client side can-i

### DIFF
--- a/cmd/reviewApps.go
+++ b/cmd/reviewApps.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"tuber/pkg/core"
 	"tuber/pkg/k8s"
 	"tuber/pkg/proto"
 	"tuber/pkg/reviewapps"
@@ -50,6 +51,19 @@ func create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer conn.Close()
+
+	_, err = core.FindApp(sourceAppName)
+	if err != nil {
+		return fmt.Errorf("source app not found")
+	}
+
+	canDeploy, err := k8s.CanDeploy(sourceAppName)
+	if err != nil {
+		return err
+	}
+	if !canDeploy {
+		return fmt.Errorf("not permitted to create a review app from %s", sourceAppName)
+	}
 
 	config, err := k8s.GetConfig()
 	if err != nil {

--- a/pkg/core/tuber.go
+++ b/pkg/core/tuber.go
@@ -109,6 +109,16 @@ func FindApp(name string) (foundApp *TuberApp, err error) {
 	return apps.FindApp(name)
 }
 
+func FindReviewApp(name string) (foundApp *TuberApp, err error) {
+	apps, err := TuberReviewApps()
+
+	if err != nil {
+		return
+	}
+
+	return apps.FindApp(name)
+}
+
 // TuberSourceApps returns a list of Tuber apps
 func TuberSourceApps() (AppList, error) {
 	sourceAppsMutex.Lock()

--- a/pkg/k8s/kubectl.go
+++ b/pkg/k8s/kubectl.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -205,19 +204,14 @@ func UseCluster(cluster string) error {
 }
 
 // CanDeploy determines if the current user can create a deployment
-func CanDeploy(appName, token string) bool {
-	if token == "" {
-		return false
-	}
-
-	t := fmt.Sprintf("--token=%s", token)
-
-	out, err := kubectl([]string{"auth", "can-i", "create", "deployments", "-n", appName, t}...)
+func CanDeploy(namespace string, args ...string) (bool, error) {
+	canDeploy := []string{"auth", "can-i", "create", "deployments", "-n", namespace}
+	out, err := kubectl(append(canDeploy, args...)...)
 	if err != nil {
-		return false
+		return false, err
 	}
 
-	return strings.Trim(string(out), "\r\n") == "yes"
+	return strings.Trim(string(out), "\r\n") == "yes", nil
 }
 
 // CurrentCluster the current configured kubectl cluster

--- a/pkg/reviewapps/permissions.go
+++ b/pkg/reviewapps/permissions.go
@@ -18,12 +18,7 @@ func canCreate(logger *zap.Logger, appName, token string) (bool, error) {
 		return false, err
 	}
 
-	canDeploy, err := k8s.CanDeploy(appName, fmt.Sprintf("--token=%s", token))
-	if err != nil {
-		return false, err
-	}
-
-	return canDeploy, nil
+	return k8s.CanDeploy(appName, fmt.Sprintf("--token=%s", token))
 }
 
 func appExists(appName string) (bool, error) {

--- a/pkg/reviewapps/permissions.go
+++ b/pkg/reviewapps/permissions.go
@@ -1,6 +1,7 @@
 package reviewapps
 
 import (
+	"fmt"
 	"tuber/pkg/core"
 	"tuber/pkg/k8s"
 
@@ -8,7 +9,7 @@ import (
 )
 
 func canCreate(logger *zap.Logger, appName, token string) (bool, error) {
-	if appName == "tuber" {
+	if appName == "tuber" || token == "" {
 		return false, nil
 	}
 
@@ -17,7 +18,12 @@ func canCreate(logger *zap.Logger, appName, token string) (bool, error) {
 		return false, err
 	}
 
-	return k8s.CanDeploy(appName, token), nil
+	canDeploy, err := k8s.CanDeploy(appName, fmt.Sprintf("--token=%s", token))
+	if err != nil {
+		return false, err
+	}
+
+	return canDeploy, nil
 }
 
 func appExists(appName string) (bool, error) {

--- a/pkg/reviewapps/reviewapps.go
+++ b/pkg/reviewapps/reviewapps.go
@@ -60,7 +60,7 @@ func CreateReviewApp(ctx context.Context, l *zap.Logger, branch string, appName 
 	}
 
 	if !permitted {
-		return "", fmt.Errorf("not permitted to create a review app")
+		return "", fmt.Errorf("not permitted to create a review app from %s", appName)
 	}
 
 	sourceApp, err := core.FindApp(appName)

--- a/pkg/reviewapps/reviewapps.go
+++ b/pkg/reviewapps/reviewapps.go
@@ -34,7 +34,7 @@ func NewReviewAppSetup(sourceApp string, reviewApp string) error {
 }
 
 func CreateReviewApp(ctx context.Context, l *zap.Logger, branch string, appName string, token string, credentials []byte, projectName string) (string, error) {
-	reviewAppName := reviewAppName(appName, branch)
+	reviewAppName := ReviewAppName(appName, branch)
 
 	list, err := core.TuberReviewApps()
 	if err != nil {
@@ -98,7 +98,7 @@ func CreateReviewApp(ctx context.Context, l *zap.Logger, branch string, appName 
 
 	logger.Info("creating and running review app trigger")
 
-	err = CreateAndRunTrigger(ctx, credentials, sourceApp.Repo, projectName, reviewAppName, branch)
+	err = CreateAndRunTrigger(ctx, logger, credentials, sourceApp.Repo, projectName, reviewAppName, branch)
 	if err != nil {
 		logger.Error("error creating trigger; no trigger resource created", zap.Error(err))
 
@@ -127,7 +127,12 @@ func CreateReviewApp(ctx context.Context, l *zap.Logger, branch string, appName 
 }
 
 func DeleteReviewApp(ctx context.Context, reviewAppName string, credentials []byte, projectName string) error {
-	err := core.DestroyTuberApp(reviewAppName)
+	_, err := core.FindReviewApp(reviewAppName)
+	if err != nil {
+		return fmt.Errorf("review app not found")
+	}
+
+	err = core.DestroyTuberApp(reviewAppName)
 	if err != nil {
 		return err
 	}
@@ -140,7 +145,7 @@ func DeleteReviewApp(ctx context.Context, reviewAppName string, credentials []by
 	return deleteReviewAppTrigger(ctx, credentials, projectName, reviewAppName)
 }
 
-func reviewAppName(appName string, branch string) string {
+func ReviewAppName(appName string, branch string) string {
 	return fmt.Sprintf("%s-%s", url.QueryEscape(appName), url.QueryEscape(branch))
 }
 

--- a/pkg/reviewapps/server.go
+++ b/pkg/reviewapps/server.go
@@ -31,7 +31,7 @@ func (s *Server) CreateReviewApp(ctx context.Context, in *proto.CreateReviewAppR
 	if s.ClusterDefaultHost == "" {
 		host = appName
 	} else {
-		host = fmt.Sprintf("https://%s.%s/", reviewAppName, s.ClusterDefaultHost)
+		host = fmt.Sprintf("https://%s.%s/", appName, s.ClusterDefaultHost)
 	}
 
 	return &proto.CreateReviewAppResponse{

--- a/pkg/reviewapps/triggers.go
+++ b/pkg/reviewapps/triggers.go
@@ -6,6 +6,7 @@ import (
 	"tuber/pkg/k8s"
 
 	"github.com/davecgh/go-spew/spew"
+	"go.uber.org/zap"
 	"google.golang.org/api/cloudbuild/v1"
 	"google.golang.org/api/option"
 )
@@ -14,7 +15,7 @@ const tuberReposConfig = "tuber-repos"
 const tuberReviewTriggersConfig = "tuber-review-triggers"
 
 // CreateAndRunTrigger creates a cloud build trigger for the review app
-func CreateAndRunTrigger(ctx context.Context, creds []byte, sourceRepo string, project string, targetAppName string, branch string) error {
+func CreateAndRunTrigger(ctx context.Context, logger *zap.Logger, creds []byte, sourceRepo string, project string, targetAppName string, branch string) error {
 	config, err := k8s.GetConfigResource(tuberReposConfig, "tuber", "configmap")
 	if err != nil {
 		return err
@@ -63,7 +64,8 @@ func CreateAndRunTrigger(ctx context.Context, creds []byte, sourceRepo string, p
 	triggerRunCall := service.Run(project, triggerCreateResult.Id, &triggerTemplate)
 	_, err = triggerRunCall.Do()
 	if err != nil {
-		return fmt.Errorf("run trigger: %w", err)
+		logger.Error(fmt.Sprintf("run trigger: %s", err.Error()))
+		return fmt.Errorf("error running trigger: does the branch exist")
 	}
 
 	return nil


### PR DESCRIPTION
client-side validations aren't just generally nice, they're also required in this case - if a user's token is stale, nothing in the existing review apps creation process refreshes it, so we're sending the expired token for server validation. this does the same checks, and in doing so, refreshes the user's token