### PR TITLE
Check for env vars in config when passing tuber a file to set

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -46,13 +46,12 @@ var envGetCmd = &cobra.Command{
 var fileCmd = &cobra.Command{
 	SilenceUsage: true,
 	Use:          "file [app] [local filepath]",
-	Short:        "batch set environment variables based on the contents of a yaml file",
+	Short:        "REPLACE all of a tuber app's env to the contents of a local yaml or json file. DESTRUCTIVE!",
 	Args:         cobra.ExactArgs(2),
 	PreRunE:      promptCurrentContext,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		appName := args[0]
 		err := k8s.CreateEnvFromFile(appName, args[1])
-
 		if err != nil {
 			return err
 		}

--- a/pkg/k8s/secrets_test.go
+++ b/pkg/k8s/secrets_test.go
@@ -1,0 +1,67 @@
+package k8s
+
+import (
+	"encoding/base64"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessData(t *testing.T) {
+	testCases := []struct {
+		name               string
+		input              []byte
+		envKeys, envValues []string
+		expected           map[string]string
+	}{
+		{
+			name:     "no data",
+			expected: nil,
+		},
+		{
+			name: "no env vars in config",
+			input: []byte(`
+FOO_DEBUG: "true"
+FOO_ENVIRONMENT: "staging"
+		`),
+			expected: map[string]string{"FOO_DEBUG": encode("true"), "FOO_ENVIRONMENT": encode("staging")},
+		},
+		{
+			name: "env vars present",
+			input: []byte(`
+FOOKEY: ${TEST_SECRET_ENV_KEY}
+FOO_COUNT: ${TEST-COUNT-123}
+`),
+			envKeys:   []string{"TEST_SECRET_ENV_KEY", "TEST-COUNT-123"},
+			envValues: []string{"env-key", "456"},
+			expected:  map[string]string{"FOOKEY": encode("env-key"), "FOO_COUNT": encode("456")},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setUnsetEnv(tc.envKeys, tc.envValues)
+
+			actual := processData(tc.input)
+
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func setUnsetEnv(keys, values []string) func() {
+	for i, k := range keys {
+		os.Setenv(k, values[i])
+	}
+
+	return func() {
+		for _, k := range keys {
+			os.Unsetenv(k)
+		}
+	}
+}
+
+func encode(in string) string {
+	return base64.StdEncoding.EncodeToString([]byte(in))
+}


### PR DESCRIPTION
This enables using local config files that point to env vars instead of saving tokens and stuff to the file itself

```
CARDINAL_SLACK_TOKEN: ${SLACK_OAUTH_TOKEN}
CARDINAL_SLACK_CHANNEL: ${SLACK_CARDINAL_CHANNEL}
CARDINAL_SENTRY_DSN: ${CARDINAL_SENTRY_DSN}
```