### PR TITLE
Add separator arg "--" for exec

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -28,7 +28,7 @@ func runExec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	execArgs := []string{"-c", containerName}
+	execArgs := []string{"-c", containerName, "--"}
 	execArgs = append(execArgs, args...)
 
 	return k8s.Exec(podName, appNameFlag, execArgs...)


### PR DESCRIPTION
Fixes kubectl warning of: `kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.`