### PR TITLE
Don't Query for Builds with no (build) trigger ID

### DIFF
--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -826,10 +826,6 @@ func (r *tuberAppResolver) CloudBuildStatuses(ctx context.Context, obj *model.Tu
 		return nil, err
 	}
 
-	if obj.TriggerID == "" {
-		return nil, nil
-	}
-
 	builds, err := builds.FindByApp(obj, r.projectName)
 	if err != nil {
 		return nil, err

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -826,6 +826,10 @@ func (r *tuberAppResolver) CloudBuildStatuses(ctx context.Context, obj *model.Tu
 		return nil, err
 	}
 
+	if obj.TriggerID == "" {
+		return nil, nil
+	}
+
 	builds, err := builds.FindByApp(obj, r.projectName)
 	if err != nil {
 		return nil, err

--- a/pkg/builds/builds.go
+++ b/pkg/builds/builds.go
@@ -22,6 +22,10 @@ func FindByApp(app *model.TuberApp, triggersProjectName string) ([]*model.Build,
 		return nil, err
 	}
 
+	if app.TriggerID == "" {
+		return make([]*model.Build, 0), nil
+	}
+
 	buildsResponse, err := cloudbuild.NewProjectsBuildsService(client).List(triggersProjectName).PageSize(3).Filter(fmt.Sprintf(`trigger_id="%s"`, app.TriggerID)).Do()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* Early exit from finding builds if a `TuberApp` doesn't have a `triggerID`

Question(s):
* Should the absence of a `triggerID` in `builds.FindByApp` return an error, or just an empty result set?