### PR TITLE
Update env file

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -67,13 +67,12 @@ var fileCmd = &cobra.Command{
 			filePath = args[0]
 		}
 
-		switch replaceFlag {
-		case true:
+		if replaceFlag {
 			err := k8s.CreateEnvFromFile(appName, filePath)
 			if err != nil {
 				return err
 			}
-		default:
+		} else {
 			err := k8s.SetEnvFromFile("deployments", appName, filePath)
 			if err != nil {
 				return err
@@ -284,7 +283,7 @@ func init() {
 	envUnsetCmd.Flags().StringVarP(&appNameFlag, "app", "a", "", "app name")
 	envCmd.AddCommand(envUnsetCmd)
 	fileCmd.Flags().StringVarP(&appNameFlag, "app", "a", "", "app name")
-	fileCmd.Flags().BoolVarP(&replaceFlag, "replace", "r", false, "replace all env variables")
+	fileCmd.Flags().BoolVarP(&replaceFlag, "replace", "r", false, "replace all env variables with contents of file")
 	envCmd.AddCommand(fileCmd)
 	envGetCmd.Flags().StringVarP(&appNameFlag, "app", "a", "", "app name")
 	envCmd.AddCommand(envGetCmd)

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -44,11 +44,12 @@ var envGetCmd = &cobra.Command{
 	PreRunE:      displayCurrentContext,
 }
 
+var replaceFlag bool
 var fileCmd = &cobra.Command{
 	SilenceUsage: true,
 	Use:          "file [appName (deprecated, use --app or -a)] [local filepath]",
 	Short:        "batch set environment variables based on the contents of a yaml file",
-	Args:         cobra.RangeArgs(1, 2),
+	Args:         cobra.RangeArgs(1, 3),
 	PreRunE:      promptCurrentContext,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var appName string
@@ -65,10 +66,18 @@ var fileCmd = &cobra.Command{
 			appName = appNameFlag
 			filePath = args[0]
 		}
-		err := k8s.CreateEnvFromFile(appName, filePath)
 
-		if err != nil {
-			return err
+		switch replaceFlag {
+		case true:
+			err := k8s.CreateEnvFromFile(appName, filePath)
+			if err != nil {
+				return err
+			}
+		default:
+			err := k8s.SetEnvFromFile("deployments", appName, filePath)
+			if err != nil {
+				return err
+			}
 		}
 
 		return k8s.Restart("deployments", appName)
@@ -275,6 +284,7 @@ func init() {
 	envUnsetCmd.Flags().StringVarP(&appNameFlag, "app", "a", "", "app name")
 	envCmd.AddCommand(envUnsetCmd)
 	fileCmd.Flags().StringVarP(&appNameFlag, "app", "a", "", "app name")
+	fileCmd.Flags().BoolVarP(&replaceFlag, "replace", "r", false, "replace all env variables")
 	envCmd.AddCommand(fileCmd)
 	envGetCmd.Flags().StringVarP(&appNameFlag, "app", "a", "", "app name")
 	envCmd.AddCommand(envGetCmd)

--- a/cmd/plant.go
+++ b/cmd/plant.go
@@ -235,8 +235,6 @@ func plant(cmd *cobra.Command, args []string) error {
 	}
 }
 
-var plantDeployFlag bool
-
 func init() {
 	plantCmd.Flags().Bool("deploy", false, "deploy tuber the first time (run without this flag first)")
 	plantCmd.Flags().String("host", "", "for the virtualservice")

--- a/pkg/k8s/secrets.go
+++ b/pkg/k8s/secrets.go
@@ -118,6 +118,26 @@ func PatchSecret(mapName string, namespace string, key string, value string) (er
 	return config.Save(namespace)
 }
 
+func BatchPatchSecret(mapName string, namespace string, data map[string]string) (err error) {
+	config, err := GetConfigResource(mapName, namespace, "Secret")
+
+	if err != nil {
+		return
+	}
+
+	for key, value := range data {
+		value = base64.StdEncoding.EncodeToString([]byte(value))
+
+		if config.Data == nil {
+			config.Data = map[string]string{key: value}
+		} else {
+			config.Data[key] = value
+		}
+	}
+
+	return config.Save(namespace)
+}
+
 // RemoveSecretEntry removes an entry, from a secret
 func RemoveSecretEntry(mapName string, namespace string, key string) (err error) {
 	config, err := GetConfigResource(mapName, namespace, "Secret")
@@ -134,4 +154,24 @@ func RemoveSecretEntry(mapName string, namespace string, key string) (err error)
 // CreateEnv creates a Secret for a new TuberApp, to store env vars
 func CreateEnv(appName string) error {
 	return Create(appName, "secret", "generic", appName+"-env")
+}
+
+func SetEnvFromFile(resource string, appName string, path string) (err error) {
+	var out []byte
+
+	out, err = ioutil.ReadFile(path)
+
+	if err != nil {
+		return
+	}
+
+	var data map[string]string
+	err = yaml.Unmarshal([]byte(out), &data)
+	if err != nil {
+		return
+	}
+
+	mapName := fmt.Sprintf("%s-env", appName)
+
+	return BatchPatchSecret(mapName, appName, data)
 }

--- a/pkg/k8s/secrets.go
+++ b/pkg/k8s/secrets.go
@@ -118,6 +118,7 @@ func PatchSecret(mapName string, namespace string, key string, value string) (er
 	return config.Save(namespace)
 }
 
+// BatchPatchSecret gets, and save multiple secrets
 func BatchPatchSecret(mapName string, namespace string, data map[string]string) (err error) {
 	config, err := GetConfigResource(mapName, namespace, "Secret")
 
@@ -156,6 +157,7 @@ func CreateEnv(appName string) error {
 	return Create(appName, "secret", "generic", appName+"-env")
 }
 
+// SetEnvFromFile update the env configuration with the contents of file
 func SetEnvFromFile(resource string, appName string, path string) (err error) {
 	var out []byte
 


### PR DESCRIPTION
Update `env file` to allow the setting of multiple env variables through a yaml file, the old behavior used to override the current env variables config.

Now we can use the **replace flag** `tuber env file env.yaml --replace` on the env file command to override the current env variables configuration, if we use the default `tuber env file env.yaml` it will just add the env variables to our configuration.

